### PR TITLE
Allow - in project name

### DIFF
--- a/gce/gce_plugin.rb
+++ b/gce/gce_plugin.rb
@@ -9,7 +9,7 @@ parameter "gce_project" do
   type "string"
   label "GCE Project"
   category "GCE Plugin"
-  allowed_pattern "^[0-9a-z:\.]+$"
+  allowed_pattern "^[0-9a-z:\.-]+$"
 end
 
 plugin "gce" do


### PR DESCRIPTION
Bug fix -- allow `-` in project name which Google allows.  Modified for customer and works with there project name now which contains a `-`