### PR TITLE
Fixes for Issue #57

### DIFF
--- a/aws/rs_aws_cft/aws_cft_plugin.rb
+++ b/aws/rs_aws_cft/aws_cft_plugin.rb
@@ -2,6 +2,7 @@ name 'rs_aws_cft'
 type 'plugin'
 rs_ca_ver 20161221
 short_description "Amazon Web Services - Cloud Formation"
+long_description "Version: 1.1"
 package "plugins/rs_aws_cft"
 import "sys_log"
 

--- a/aws/rs_aws_cft/aws_cft_plugin.rb
+++ b/aws/rs_aws_cft/aws_cft_plugin.rb
@@ -615,12 +615,12 @@ plugin "rs_aws_cft" do
 
     output "OutputKey" do
       body_path "//DescribeStacksResult/Stacks/member/Outputs/member/OutputKey"
-      type "simple_element"
+      type "array"
     end
 
     output "OutputValue" do
       body_path "//DescribeStacksResult/Stacks/member/Outputs/member/OutputValue"
-      type "simple_element"
+      type "array"
     end 
 
     provision "create_stack"

--- a/aws/rs_aws_cft/cft_test_cat.rb
+++ b/aws/rs_aws_cft/cft_test_cat.rb
@@ -2,8 +2,12 @@ name "CFT Plugin Test"
 rs_ca_ver 20161221
 short_description  "CFT Test"
 long_description ""
+
 import "plugins/rs_aws_cft"
 
+output "out_domain_name" do
+  label "Domain Name"
+end
 
 resource "stack", type: "rs_aws_cft.stack" do
   stack_name join(["cft-", last(split(@@deployment.href, "/"))])
@@ -16,6 +20,50 @@ operation "launch" do
   definition "launch_handler"
 end
 
+# Demonstrates how to get outputs
+# Over complicated example given the single output returned by the example CFT.
+# But hopefully it helps when faced with a CFT that returns multiple outputs.
+operation "enable" do
+  definition "post_launch"
+  output_mappings do {
+    $out_domain_name => $domain_name
+  } end
+end
+
+define launch_handler(@stack) return $cft_template,@stack do
+  call generate_cloudformation_template() retrieve $cft_template
+  task_label("provision CFT Stack")
+  $stack = to_object(@stack)
+  $stack["fields"]["template_body"] = $cft_template
+  @stack = $stack
+  provision(@stack)
+end
+
+# Outputs are provided as two arrays. 
+# One array contains the keys. The other array contains the values.
+# Given the CFT example and the fact that it returns a single input, the code below could be replaced with 
+#    $domain_name = $OutputValue[0]
+# But what's the fun in that ...?
+define post_launch(@stack) return $domain_name do
+
+  $output_keys = @stack.OutputKey
+  $output_values = @stack.OutputValue
+  
+  $i = 0
+  foreach $output_key in $output_keys do
+    if $output_key == "DomainName"
+      $domain_name = $output_values[$i]
+    elsif $output_key == "AnotherOutput"  # this will fire given the CFT example. Provided as an example bit of code.
+      $another_output = $output_values[$i]
+    end
+    $i = $i + 1
+  end
+  
+  
+end
+
+
+# Example CFT
 define generate_cloudformation_template() return $cft_template do
   $cft_template = to_s('{ "AWSTemplateFormatVersion": "2010-09-09",
   "Resources": {
@@ -89,14 +137,4 @@ define generate_cloudformation_template() return $cft_template do
   },
   "Description": "Cloudfront Definition for RS"
 }')
-end
-
-define launch_handler(@stack) return $cft_template,@stack,@resources do
-  call generate_cloudformation_template() retrieve $cft_template
-  task_label("provision CFT Stack")
-  $stack = to_object(@stack)
-  $stack["fields"]["template_body"] = $cft_template
-  @stack = $stack
-  provision(@stack)
-  @resources = @stack.resources()
 end

--- a/aws/rs_aws_cft/changelog.md
+++ b/aws/rs_aws_cft/changelog.md
@@ -3,3 +3,8 @@ CFT Plugin changelog
 v1.0
 -----
 - initial release
+
+v1.1
+-----
+- Updated to support an array of more than 1 output from the CFT.
+- Updated test CAT to show how to access the outputs.


### PR DESCRIPTION
In a nutshell, changed outputvalues and outputkeys to be arrays instead of simple_elements.

Updated the test CAT to show how to return the outputs.
If there's some clever way to merge two arrays into a hash, please let me know since that would be prettier code.

Tested the test CAT as well as nested CFT CAT and the "RedShift CFT" CAT in demo.