### PR TITLE
rs_azure_networking: Test Cat Fix

### DIFF
--- a/azure/rs_azure_networking/lb_test_cat.rb
+++ b/azure/rs_azure_networking/lb_test_cat.rb
@@ -162,7 +162,7 @@ define add_to_lb(@server,@my_pub_lb) return @server,@my_target_nic do
       call stop_debugging()
       call sys_log.detail("nic:"+to_s(@nic))
       call sys_log.detail("nic_name:" + @nic.name)
-      if @nic.name =~ @server.name +"-default"
+      if @nic.name =~ @server.name
         @my_target_nic = @nic
         call sys_log.detail("target nic: true")
       else


### PR DESCRIPTION
### Description

Removes the hardcoding of the subnet name in the NIC regex check.

### Issues Resolved

Fixes the dependency of the subnet name being 'default'.

### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
