### PR TITLE
rs_azure_networking: custom terminate on lb test cat

### DIFF
--- a/azure/rs_azure_networking/lb_test_cat.rb
+++ b/azure/rs_azure_networking/lb_test_cat.rb
@@ -126,6 +126,10 @@ operation "launch" do
   } end
 end
 
+operation "terminate" do 
+  definition "terminate"
+end
+
 define launch_handler(@server1,@server2,@lb_ip,@my_pub_lb,$subscription_id) return @server1,@server2,@lb_ip,@my_pub_lb,$pool_id,$lb_ip do
   task_label("Provisioning Server")
   concurrent return @server1, @server2 do
@@ -207,4 +211,11 @@ define stop_debugging() do
     call sys_log.detail($debug_report)
     $$debugging = false
   end
+end
+
+define terminate(@server1,@server2,@lb_ip,@my_pub_lb) return @server1,@server2,@lb_ip,@my_pub_lb do
+  delete(@server1)
+  delete(@server2)
+  delete(@my_pub_lb)
+  delete(@lb_ip)
 end


### PR DESCRIPTION
### Description

Adds a custom terminate to the lb test cat to allow for all resources to be properly terminated.

### Issues Resolved

Resources fail to be terminated.

### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
