### PR TITLE
rs_azure_networking: added list_all action to network type

### DIFF
--- a/azure/rs_azure_networking/README.md
+++ b/azure/rs_azure_networking/README.md
@@ -190,6 +190,7 @@ end
 | destroy | [Delete](https://docs.microsoft.com/en-us/rest/api/virtualnetwork/virtualnetworks/delete) | Supported |
 | get | [Get](https://docs.microsoft.com/en-us/rest/api/virtualnetwork/virtualnetworks/get)| Supported |
 | list | [Get](https://docs.microsoft.com/en-us/rest/api/virtualnetwork/virtualnetworks/list)| Supported |
+| list_all | [Get](https://docs.microsoft.com/en-us/rest/api/virtualnetwork/virtualnetworks/listall)| Supported |
 
 #### Supported Outputs
 - id

--- a/azure/rs_azure_networking/changelog.md
+++ b/azure/rs_azure_networking/changelog.md
@@ -1,5 +1,9 @@
 Networking Plugin changelog
 
+v1.3 (02-09-2018)
+-----------------
+- Added `list_all` action to the `network` type
+
 v1.2 (12-08-2017)
 -----------------
 - moved vNet Peering resource under the `rs_azure_networking` plugin

--- a/azure/rs_azure_networking/rs_azure_networking_plugin.rb
+++ b/azure/rs_azure_networking/rs_azure_networking_plugin.rb
@@ -2,7 +2,7 @@ name 'rs_azure_networking_plugin'
 type 'plugin'
 rs_ca_ver 20161221
 short_description "Azure Networking Plugin"
-long_description "Version: 1.2"
+long_description "Version: 1.3"
 package "plugins/rs_azure_networking_plugin"
 import "sys_log"
 
@@ -264,6 +264,13 @@ plugin "rs_azure_networking" do
       field "resource_group" do
         location "path"
       end
+
+      output_path "value[*]"
+    end
+    
+    action "list_all" do
+      path "/subscriptions/$subscription_id/providers/Microsoft.Network/virtualNetworks"
+      verb "GET"
 
       output_path "value[*]"
     end


### PR DESCRIPTION
### Description
Added the `list_all` action to the type `network`. Adds the ability to list all vNets in a subscription without providing a Resource Group

### Issues Resolved
n/a

### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
