### PR TITLE
AWS RDS Plugin: updating mysql version to working version

### DIFF
--- a/aws/rs_aws_rds/rds_test_cat.rb
+++ b/aws/rs_aws_rds/rds_test_cat.rb
@@ -51,7 +51,7 @@ resource "my_rds", type: "rs_aws_rds.db_instance" do
   db_name join(["mydb", last(split(@@deployment.href, "/"))])
   db_subnet_group_name "db-sub-grp-8172a6f8"
   engine "mysql"
-  engine_version "5.7.11" 
+  engine_version "5.7" 
   master_username "my_user"
   master_user_password "pa$$w0rd1"
   storage_encrypted "false"


### PR DESCRIPTION
 

### Description

Allows for the test CAT to use a non minor version

### Issues Resolved

[Cannot find version 5.7.11 for mysql]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
