### PR TITLE
fixed issue with max 255 characters for summary entry

### DIFF
--- a/aws/rs_aws_rds/aws_rds_plugin.rb
+++ b/aws/rs_aws_rds/aws_rds_plugin.rb
@@ -2,7 +2,7 @@ name 'aws_rds_plugin'
 type 'plugin'
 rs_ca_ver 20161221
 short_description "Amazon Web Services - Relational Database Service"
-long_description "Version: 1.4"
+long_description "Version: 1.5"
 package "plugins/rs_aws_rds"
 import "sys_log"
 import "plugin_generics"
@@ -731,7 +731,7 @@ define handle_retries($attempts) do
   if $attempts <= 6
     sleep(10*to_n($attempts))
     call sys_log.set_task_target(@@deployment)
-    call sys_log.summary("error:"+$_error["type"] + ": " + $_error["message"])
+    call sys_log.summary("RDS Plugin"])
     call sys_log.detail("error:"+$_error["type"] + ": " + $_error["message"])
     log_error($_error["type"] + ": " + $_error["message"])
     $_error_behavior = "retry"

--- a/aws/rs_aws_rds/changelog.md
+++ b/aws/rs_aws_rds/changelog.md
@@ -1,5 +1,9 @@
 RDS Plugin changelog
 
+v1.5 (05-12-2018)
+-----
+- bugfix: changed summary to "RDS Plugin" instead of inserting 255+ characters in the error msg.
+
 v1.4 (12-13-2017)
 -----
 - updating start_debugging,stop_debugging to use the proper context


### PR DESCRIPTION
### Description

Sets the summary of the audit entry to RDS Plugin, instead of the full error msg (>255 characters)

### Issues Resolved

https://github.com/rightscale/rightscale-plugins/issues/157

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
